### PR TITLE
Sort model list attributes on output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.0.1 Release
+
+- Sort model attributes alphabetically where order is not relevant. Mostly to prevent displaying diffs on those attributes.
+
 ## Version 1.0.0 Release
 
 Initial public release of the Panoramic CLI tool.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("src/panoramic/cli/__version__.py", encoding="utf8") as f:
     version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)  # type: ignore
 
 TEST_REQUIRES = ["pytest>=5.3.5", "responses>=0.10.14", "freezegun>=0.3.15", "pytest-recording>=0.8.1"]
-DEV_REQUIRES = ["mypy>=0.780", "flake8>=3.8.3", "black>=19.10b0", "pre-commit>=2.1.1"]
+DEV_REQUIRES = ["mypy>=0.780", "flake8>=3.8.3", "black==19.10b0", "pre-commit>=2.1.1"]
 
 setup(
     name="panoramic-cli",

--- a/src/panoramic/cli/__version__.py
+++ b/src/panoramic/cli/__version__.py
@@ -1,2 +1,2 @@
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __minimum_supported_version__ = "1.0.0"

--- a/src/panoramic/cli/pano_model.py
+++ b/src/panoramic/cli/pano_model.py
@@ -42,6 +42,9 @@ class PanoModelField:
         return cls(
             field_map=inputs['field_map'], data_reference=inputs['data_reference'], data_type=inputs['data_type'],
         )
+    
+    def identifier(self) -> str:
+        return f'{self.data_reference}_{self.data_type}_{",".join(sorted(self.field_map))}'
 
     def __hash__(self) -> int:
         return hash(self.to_dict())
@@ -83,6 +86,9 @@ class PanoModelJoin:
             relationship=inputs['relationship'],
             to_model=inputs['to_model'],
         )
+    
+    def identifier(self) -> str:
+        return f'{self.join_type}_{self.relationship}_{self.to_model}_{",".join(sorted(self.fields))}'
 
     def __hash__(self) -> int:
         return hash(self.to_dict())
@@ -136,9 +142,9 @@ class PanoModel(Actionable):
             'api_version': self.API_VERSION,
             'model_name': self.model_name,
             'data_source': self.data_source,
-            'fields': [x.to_dict() for x in self.fields],
-            'joins': [x.to_dict() for x in self.joins],
-            'identifiers': self.identifiers,
+            'fields': [x.to_dict() for x in sorted(self.fields, key=lambda field: field.identifier())],
+            'joins': [x.to_dict() for x in sorted(self.joins, key=lambda join: join.identifier())],
+            'identifiers': sorted(self.identifiers),
             # The virtual_data_source and package are not exported to yaml
         }
 

--- a/src/panoramic/cli/pano_model.py
+++ b/src/panoramic/cli/pano_model.py
@@ -40,9 +40,7 @@ class PanoModelField:
     @classmethod
     def from_dict(cls, inputs: Dict[str, Any]) -> 'PanoModelField':
         return cls(
-            field_map=inputs['field_map'],
-            data_reference=inputs['data_reference'],
-            data_type=inputs['data_type'],
+            field_map=inputs['field_map'], data_reference=inputs['data_reference'], data_type=inputs['data_type'],
         )
 
     def identifier(self) -> str:

--- a/src/panoramic/cli/pano_model.py
+++ b/src/panoramic/cli/pano_model.py
@@ -47,7 +47,7 @@ class PanoModelField:
         return f'{self.data_reference}_{self.data_type}_{",".join(sorted(self.field_map))}'
 
     def __hash__(self) -> int:
-        return hash(self.to_dict())
+        return hash(self.identifier())
 
     def __eq__(self, o: object) -> bool:
         if not isinstance(o, PanoModelField):
@@ -91,7 +91,7 @@ class PanoModelJoin:
         return f'{self.join_type}_{self.relationship}_{self.to_model}_{",".join(sorted(self.fields))}'
 
     def __hash__(self) -> int:
-        return hash(self.to_dict())
+        return hash(self.identifier())
 
     def __eq__(self, o: object) -> bool:
         if not isinstance(o, PanoModelJoin):

--- a/src/panoramic/cli/pano_model.py
+++ b/src/panoramic/cli/pano_model.py
@@ -40,9 +40,11 @@ class PanoModelField:
     @classmethod
     def from_dict(cls, inputs: Dict[str, Any]) -> 'PanoModelField':
         return cls(
-            field_map=inputs['field_map'], data_reference=inputs['data_reference'], data_type=inputs['data_type'],
+            field_map=inputs['field_map'],
+            data_reference=inputs['data_reference'],
+            data_type=inputs['data_type'],
         )
-    
+
     def identifier(self) -> str:
         return f'{self.data_reference}_{self.data_type}_{",".join(sorted(self.field_map))}'
 
@@ -86,7 +88,7 @@ class PanoModelJoin:
             relationship=inputs['relationship'],
             to_model=inputs['to_model'],
         )
-    
+
     def identifier(self) -> str:
         return f'{self.join_type}_{self.relationship}_{self.to_model}_{",".join(sorted(self.fields))}'
 


### PR DESCRIPTION
Sorts model list attributes, where order is not important.
This is to prevent `--diff` from outputing changes that are not relevant