### PR TITLE
Join detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.1.0 Release
+
+- This release introduces a new `detect-joins` CLI command.
+
 ## Version 1.0.2 Release
 
 - Disallow `"one_to_many"` and `"many_to_many"` join types, since they are not supported anyway.

--- a/src/panoramic/cli/__version__.py
+++ b/src/panoramic/cli/__version__.py
@@ -1,2 +1,2 @@
-__version__ = "1.0.2"
+__version__ = "1.1.0"
 __minimum_supported_version__ = "1.0.0"

--- a/src/panoramic/cli/cli.py
+++ b/src/panoramic/cli/cli.py
@@ -165,7 +165,7 @@ def validate():
 
 @cli.command(help='Detect joins under a dataset', cls=LocalStateAwareCommand)
 @click.option('--target-dataset', '-t', type=str, help='Target a specific dataset')
-@click.option('--diff', '-d', is_flag=True, help='Show the difference between local and remote state')
+@click.option('--diff', '-d', is_flag=True, help='Show the difference between local and detected joins')
 @click.option('--overwrite', is_flag=True, default=False)
 @handle_exception
 def detect_joins(target_dataset: str, diff: bool, overwrite: bool):

--- a/src/panoramic/cli/cli.py
+++ b/src/panoramic/cli/cli.py
@@ -101,7 +101,7 @@ def scan(source_id: str, filter: Optional[str], parallel: int, generate_identifi
 
 
 @cli.command(help='Pull models from remote', cls=LocalStateAwareCommand)
-@click.option('--yes', '-y', is_flag=True, default=False)
+@click.option('--yes', '-y', is_flag=True, default=False, help='Automatically confirm all actions')
 @click.option('--target-dataset', '-t', type=str, help='Target a specific dataset')
 @click.option('--diff', '-d', is_flag=True, help='Show the difference between local and remote state')
 @handle_exception
@@ -112,7 +112,7 @@ def pull(yes: bool, target_dataset: str, diff: bool):
 
 
 @cli.command(help='Push models to remote', cls=LocalStateAwareCommand)
-@click.option('--yes', '-y', is_flag=True, default=False)
+@click.option('--yes', '-y', is_flag=True, default=False, help='Automatically confirm all actions')
 @click.option('--target-dataset', '-t', type=str, help='Target a specific dataset')
 @click.option('--diff', '-d', is_flag=True, help='Show the difference between local and remote state')
 @handle_exception
@@ -165,11 +165,14 @@ def validate():
 
 @cli.command(help='Detect joins under a dataset', cls=LocalStateAwareCommand)
 @click.option('--target-dataset', '-t', type=str, help='Target a specific dataset')
+@click.option('--yes', '-y', is_flag=True, default=False, help='Automatically confirm all actions')
 @click.option('--diff', '-d', is_flag=True, help='Show the difference between local and detected joins')
-@click.option('--overwrite', is_flag=True, default=False)
+@click.option(
+    '--overwrite', is_flag=True, default=False, help='Overwrite joins on local model files by suggestions from remote'
+)
 @handle_exception
-def detect_joins(target_dataset: str, diff: bool, overwrite: bool):
+def detect_joins(target_dataset: str, yes: bool, diff: bool, overwrite: bool):
     from panoramic.cli.command import detect_joins as detect_joins_command
 
-    if not detect_joins_command(target_dataset=target_dataset, diff=diff, overwrite=overwrite):
+    if not detect_joins_command(target_dataset=target_dataset, diff=diff, overwrite=overwrite, yes=yes):
         sys.exit(1)

--- a/src/panoramic/cli/cli.py
+++ b/src/panoramic/cli/cli.py
@@ -19,7 +19,6 @@ from panoramic.cli.print import echo_error, echo_errors
 
 
 class ConfigAwareCommand(Command):
-
     """Perform config file validation before running command."""
 
     def invoke(self, ctx: Context):
@@ -34,7 +33,6 @@ class ConfigAwareCommand(Command):
 
 
 class ContextAwareCommand(ConfigAwareCommand):
-
     """
     Perform config and context file validation before running command.
 
@@ -58,7 +56,6 @@ class ContextAwareCommand(ConfigAwareCommand):
 
 
 class LocalStateAwareCommand(ContextAwareCommand):
-
     """Perform config, context, and local state files validation before running command."""
 
     def invoke(self, ctx: Context):
@@ -163,4 +160,16 @@ def validate():
     from panoramic.cli.command import validate as validate_command
 
     if not validate_command():
+        sys.exit(1)
+
+
+@cli.command(help='Detect joins under a dataset', cls=LocalStateAwareCommand)
+@click.option('--target-dataset', '-t', type=str, help='Target a specific dataset')
+@click.option('--diff', '-d', is_flag=True, help='Show the difference between local and remote state')
+@click.option('--overwrite', is_flag=True, default=False)
+@handle_exception
+def detect_joins(target_dataset: str, diff: bool, overwrite: bool):
+    from panoramic.cli.command import detect_joins as detect_joins_command
+
+    if not detect_joins_command(target_dataset=target_dataset, diff=diff, overwrite=overwrite):
         sys.exit(1)

--- a/src/panoramic/cli/command.py
+++ b/src/panoramic/cli/command.py
@@ -260,6 +260,7 @@ def push(yes: bool = False, target_dataset: Optional[str] = None, diff: bool = F
 
 
 def detect_joins(target_dataset: Optional[str] = None, diff: bool = False, overwrite: bool = False):
+    """Detect joins in local state."""
     company_slug = get_company_slug()
     echo_info('Loading local state...')
     local_state = get_local_state(target_dataset=target_dataset)

--- a/src/panoramic/cli/command.py
+++ b/src/panoramic/cli/command.py
@@ -1,5 +1,7 @@
 import logging
+from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
 from typing import Any, Dict, Optional
 
 import click
@@ -12,13 +14,16 @@ from panoramic.cli.diff import echo_diff
 from panoramic.cli.errors import (
     InvalidDatasetException,
     InvalidModelException,
+    JoinException,
     ValidationError,
 )
 from panoramic.cli.file_utils import write_yaml
 from panoramic.cli.identifier_generator import IdentifierGenerator
+from panoramic.cli.join_detector import JoinDetector
 from panoramic.cli.local import get_state as get_local_state
 from panoramic.cli.local.executor import LocalExecutor
 from panoramic.cli.local.writer import FileWriter
+from panoramic.cli.pano_model import PanoModel
 from panoramic.cli.paths import Paths
 from panoramic.cli.physical_data_source.client import PhysicalDataSourceClient
 from panoramic.cli.print import echo_error, echo_errors, echo_info
@@ -26,6 +31,7 @@ from panoramic.cli.refresh import Refresher
 from panoramic.cli.remote import get_state as get_remote_state
 from panoramic.cli.remote.executor import RemoteExecutor
 from panoramic.cli.scan import Scanner
+from panoramic.cli.state import Action, ActionList
 from panoramic.cli.validate import (
     validate_config,
     validate_context,
@@ -251,3 +257,58 @@ def push(yes: bool = False, target_dataset: Optional[str] = None, diff: bool = F
             except Exception as e:
                 bar.write(f'Error: Failed to execute action {action.description}:\n  {str(e)}')
         bar.write(f'Updated {bar.total} models')
+
+
+def detect_joins(target_dataset: Optional[str] = None, diff: bool = False, overwrite: bool = False):
+    company_slug = get_company_slug()
+    echo_info('Loading local state...')
+    local_state = get_local_state(target_dataset=target_dataset)
+
+    join_detector = JoinDetector(company_slug=company_slug)
+    join_detector.fetch_token()
+
+    models_by_virtual_data_source: Dict[str, Dict[str, PanoModel]] = defaultdict(dict)
+    for model in local_state.models:
+        models_by_virtual_data_source[model.virtual_data_source][model.model_name].append(model)
+
+    actions_list = ActionList(actions=[])
+
+    for dataset in local_state.data_sources:
+        try:
+            echo_info(f'Detecting joins for dataset {dataset}')
+            joins_by_model = join_detector.detect(dataset.dataset_slug)
+
+            with tqdm(list(joins_by_model.items())) as bar:
+                for model_name, joins in bar:
+                    if not joins:
+                        echo_info(f'No joins detected for {model_name} under dataset {dataset}')
+                        continue
+
+                    bar.write(f'Detected {len(joins)} joins for {model_name} under dataset {dataset}')
+                    current_model = models_by_virtual_data_source[dataset][model_name]
+                    desired_model = deepcopy(current_model)
+
+                    if overwrite:
+                        desired_model.joins = joins
+                    else:
+                        desired_model.joins = current_model.joins + joins
+
+                    actions_list.actions.append(Action(current=current_model, desired=desired_model))
+
+        except JoinException as join_exception:
+            echo_error(f'{str(join_exception)}')
+        except Exception:
+            echo_error(f'An unexpected error occured when detecting joins for {dataset}.')
+
+    echo_diff(actions_list)
+    if diff:
+        return
+
+    executor = LocalExecutor()
+    with tqdm(actions_list.actions) as execute_bar:
+        for action in execute_bar:
+            try:
+                executor.execute(action)
+            except Exception:
+                bar.write(f'Error: Failed to execute action {action.description}')
+        execute_bar.write(f'Updated {execute_bar.total} models')

--- a/src/panoramic/cli/command.py
+++ b/src/panoramic/cli/command.py
@@ -326,10 +326,11 @@ def detect_joins(target_dataset: Optional[str] = None, diff: bool = False, overw
     echo_info('Updating local state...')
 
     executor = LocalExecutor()
-    with tqdm(actions_list.actions) as execute_bar:
-        for action in execute_bar:
-            try:
-                executor.execute(action)
-            except Exception:
-                bar.write(f'Error: Failed to execute action {action.description}')
-        execute_bar.write(f'Updated {execute_bar.total} models')
+    updated_count = 0
+    for action in actions_list.actions:
+        try:
+            executor.execute(action)
+            updated_count += 1
+        except Exception:
+            echo_error(f'Error: Failed to execute action {action.description}')
+        echo_info(f'Updated {updated_count} models')

--- a/src/panoramic/cli/config/join.py
+++ b/src/panoramic/cli/config/join.py
@@ -1,0 +1,7 @@
+import os
+
+BASE_URL = 'https://diesel.panoramicapi.com/api/v1/federated/join/'
+
+
+def get_base_url() -> str:
+    return os.environ.get('PANO_JOIN_BASE_URL', BASE_URL)

--- a/src/panoramic/cli/errors.py
+++ b/src/panoramic/cli/errors.py
@@ -51,6 +51,14 @@ class IdentifierException(CliBaseException):
         super().__init__(f'Identifiers could not be generated for table {table_name} in data connection {source_name}')
 
 
+class JoinException(CliBaseException):
+
+    """Error detecting joins in a dataset."""
+
+    def __init__(self, dataset_name: str):
+        super().__init__(f'Joins could not be detected for {dataset_name}')
+
+
 class RefreshException(CliBaseException):
 
     """Error refreshing metadata."""
@@ -73,6 +81,14 @@ class SourceNotFoundException(CliBaseException):
 
     def __init__(self, source_name: str):
         super().__init__(f'Data connection {source_name} not found. Has it been connected?')
+
+
+class DatasetNotFoundException(CliBaseException):
+
+    """Thrown when a dataset cannot be found."""
+
+    def __init__(self, dataset_name: str):
+        super().__init__(f'Dataset {dataset_name} not found. Has it been created?')
 
 
 class ScanException(CliBaseException):

--- a/src/panoramic/cli/identifier/client.py
+++ b/src/panoramic/cli/identifier/client.py
@@ -42,7 +42,7 @@ class IdentifierClient(OAuth2Client):
         """Starts async "id parsing" job and return job id."""
         url = urljoin(self.base_url, f'{source_id}')
         params = {'company_slug': company_slug, 'table_name': table_name}
-        logger.debug(f'Requesting columns for source {source_id} and filter: {table_name}')
+        logger.debug(f'Triggering a job for source {source_id} and table name: {table_name}')
         response = self.session.post(url, params=params, timeout=5)
         response.raise_for_status()
         return response.json()['data']['job_id']

--- a/src/panoramic/cli/join/__init__.py
+++ b/src/panoramic/cli/join/__init__.py
@@ -1,0 +1,6 @@
+from panoramic.cli.join.client import JoinClient, JobState
+
+__all__ = [
+    'JoinClient',
+    'JobState',
+]

--- a/src/panoramic/cli/join/__init__.py
+++ b/src/panoramic/cli/join/__init__.py
@@ -1,4 +1,4 @@
-from panoramic.cli.join.client import JoinClient, JobState
+from panoramic.cli.join.client import JobState, JoinClient
 
 __all__ = [
     'JoinClient',

--- a/src/panoramic/cli/join/client.py
+++ b/src/panoramic/cli/join/client.py
@@ -24,7 +24,7 @@ TERMINAL_STATES = {JobState.COMPLETED, JobState.FAILED}
 
 class JoinClient(OAuth2Client):
 
-    """Identifier Parser HTTP API client."""
+    """Join Detection HTTP API client."""
 
     base_url: str
 

--- a/src/panoramic/cli/join/client.py
+++ b/src/panoramic/cli/join/client.py
@@ -40,8 +40,8 @@ class JoinClient(OAuth2Client):
 
     def create_join_detection_job(self, company_slug: str, dataset_id: str) -> str:
         """Starts async "join detection" job and return job id."""
-        url = urljoin(self.base_url, f'{dataset_id}')
-        logger.debug(f'Triggering a job for dataset {dataset_id}')
+        url = urljoin(self.base_url, dataset_id)
+        logger.debug(f'Triggering a join detection job for dataset {dataset_id}')
         response = self.session.post(url, params={'company_slug': company_slug}, timeout=5)
         response.raise_for_status()
         return response.json()['data']['job_id']
@@ -57,7 +57,7 @@ class JoinClient(OAuth2Client):
     def get_job_results(self, company_slug: str, job_id: str) -> Dict[str, Any]:
         """Get results of an async job."""
         url = urljoin(self.base_url, f'job/{job_id}')
-        logger.debug(f'Getting job results for job {job_id} under company {company_slug}')
+        logger.debug(f'Getting join detection job results for job {job_id} under company {company_slug}')
         response = self.session.get(url, params={'company_slug': company_slug}, timeout=5)
         response.raise_for_status()
         return response.json()['data']

--- a/src/panoramic/cli/join/client.py
+++ b/src/panoramic/cli/join/client.py
@@ -1,0 +1,77 @@
+import logging
+import time
+from enum import Enum
+from typing import Any, Dict, Optional
+from urllib.parse import urljoin
+
+from panoramic.auth import OAuth2Client
+from panoramic.cli.config.auth import get_client_id, get_client_secret
+from panoramic.cli.config.join import get_base_url
+from panoramic.cli.errors import TimeoutException
+
+logger = logging.getLogger(__name__)
+
+
+class JobState(Enum):
+
+    RUNNING = 'RUNNING'
+    COMPLETED = 'COMPLETED'
+    FAILED = 'FAILED'
+
+
+TERMINAL_STATES = {JobState.COMPLETED, JobState.FAILED}
+
+
+class JoinClient(OAuth2Client):
+
+    """Identifier Parser HTTP API client."""
+
+    base_url: str
+
+    def __init__(
+        self, base_url: Optional[str] = None, client_id: Optional[str] = None, client_secret: Optional[str] = None
+    ):
+        client_id = client_id if client_id is not None else get_client_id()
+        client_secret = client_secret if client_secret is not None else get_client_secret()
+
+        self.base_url = base_url if base_url is not None else get_base_url()
+
+        super().__init__(client_id, client_secret)
+
+    def create_join_detection_job(self, company_slug: str, dataset_id: str) -> str:
+        """Starts async "join detection" job and return job id."""
+        url = urljoin(self.base_url, f'{dataset_id}')
+        logger.debug(f'Triggering a job for dataset {dataset_id}')
+        response = self.session.post(url, params={'company_slug': company_slug}, timeout=5)
+        response.raise_for_status()
+        return response.json()['data']['job_id']
+
+    def get_job_status(self, job_id: str) -> JobState:
+        """Get status of an async job."""
+        url = urljoin(self.base_url, f'job/{job_id}')
+        logger.debug(f'Getting job status for job {job_id}')
+        response = self.session.get(url, timeout=5)
+        response.raise_for_status()
+        return JobState(response.json()['data']['status'])
+
+    def get_job_results(self, job_id: str) -> Dict[str, Any]:
+        """Get results of an async job."""
+        url = urljoin(self.base_url, f'job/{job_id}')
+        logger.debug(f'Getting job results for job {job_id}')
+        response = self.session.get(url, timeout=5)
+        response.raise_for_status()
+        return response.json()['data']
+
+    def wait_for_terminal_state(self, job_id: str, timeout: int = 60) -> JobState:
+        """Wait for job to reach terminal state."""
+        tick_time = 1
+        while True:
+            logger.debug(f'Getting status for job with id {job_id}')
+            status = self.get_job_status(job_id)
+            logger.debug(f'Got status {status} for job with id {job_id}')
+            if status in TERMINAL_STATES:
+                return status
+            if timeout <= 0:
+                raise TimeoutException(f'Timed out waiting for job {job_id} to complete')
+            time.sleep(tick_time)
+            timeout -= tick_time

--- a/src/panoramic/cli/join/client.py
+++ b/src/panoramic/cli/join/client.py
@@ -46,32 +46,32 @@ class JoinClient(OAuth2Client):
         response.raise_for_status()
         return response.json()['data']['job_id']
 
-    def get_job_status(self, job_id: str) -> JobState:
+    def get_job_status(self, company_slug: str, job_id: str) -> JobState:
         """Get status of an async job."""
         url = urljoin(self.base_url, f'job/{job_id}')
-        logger.debug(f'Getting job status for job {job_id}')
-        response = self.session.get(url, timeout=5)
+        logger.debug(f'Getting job status for job {job_id} under company {company_slug}')
+        response = self.session.get(url, params={'company_slug': company_slug}, timeout=5)
         response.raise_for_status()
         return JobState(response.json()['data']['status'])
 
-    def get_job_results(self, job_id: str) -> Dict[str, Any]:
+    def get_job_results(self, company_slug: str, job_id: str) -> Dict[str, Any]:
         """Get results of an async job."""
         url = urljoin(self.base_url, f'job/{job_id}')
-        logger.debug(f'Getting job results for job {job_id}')
-        response = self.session.get(url, timeout=5)
+        logger.debug(f'Getting job results for job {job_id} under company {company_slug}')
+        response = self.session.get(url, params={'company_slug': company_slug}, timeout=5)
         response.raise_for_status()
         return response.json()['data']
 
-    def wait_for_terminal_state(self, job_id: str, timeout: int = 60) -> JobState:
+    def wait_for_terminal_state(self, company_slug: str, job_id: str, timeout: int = 60) -> JobState:
         """Wait for job to reach terminal state."""
         tick_time = 1
         while True:
-            logger.debug(f'Getting status for job with id {job_id}')
-            status = self.get_job_status(job_id)
-            logger.debug(f'Got status {status} for job with id {job_id}')
+            logger.debug(f'Getting status for job with id {job_id} under company {company_slug}')
+            status = self.get_job_status(company_slug, job_id)
+            logger.debug(f'Got status {status} for job with id {job_id} under company {company_slug}')
             if status in TERMINAL_STATES:
                 return status
             if timeout <= 0:
-                raise TimeoutException(f'Timed out waiting for job {job_id} to complete')
+                raise TimeoutException(f'Timed out waiting for job {job_id} under company {company_slug} to complete')
             time.sleep(tick_time)
             timeout -= tick_time

--- a/src/panoramic/cli/join_detector.py
+++ b/src/panoramic/cli/join_detector.py
@@ -24,7 +24,7 @@ class JoinDetector:
         self.client.fetch_token()
 
     def detect(self, dataset_id: str, timeout: int = 60) -> Dict[str, List[PanoModelJoin]]:
-        """Generate identifiers for a given table."""
+        """Detect possible joins between models under a dataset."""
         logger.debug(f'Starting join detection job for dataset {dataset_id}')
         try:
             job_id = self.client.create_join_detection_job(self.company_slug, dataset_id)

--- a/src/panoramic/cli/join_detector.py
+++ b/src/panoramic/cli/join_detector.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import Dict, List
 
 import requests
 from requests import RequestException
@@ -23,7 +23,7 @@ class JoinDetector:
     def fetch_token(self):
         self.client.fetch_token()
 
-    def detect(self, dataset_id: str, timeout: int = 60) -> List[PanoModelJoin]:
+    def detect(self, dataset_id: str, timeout: int = 60) -> Dict[str, List[PanoModelJoin]]:
         """Generate identifiers for a given table."""
         logger.debug(f'Starting join detection job for dataset {dataset_id}')
         try:

--- a/src/panoramic/cli/join_detector.py
+++ b/src/panoramic/cli/join_detector.py
@@ -1,0 +1,45 @@
+import logging
+from typing import List
+
+import requests
+from requests import RequestException
+
+from panoramic.cli.errors import DatasetNotFoundException, JoinException
+from panoramic.cli.join import JobState, JoinClient
+from panoramic.cli.pano_model import PanoModelJoin
+
+logger = logging.getLogger(__name__)
+
+
+class JoinDetector:
+    def __init__(self, company_slug: str, client: JoinClient = None):
+        self.company_slug = company_slug
+
+        if client is None:
+            client = JoinClient()
+
+        self.client = client
+
+    def fetch_token(self):
+        self.client.fetch_token()
+
+    def detect(self, dataset_id: str, timeout: int = 60) -> List[PanoModelJoin]:
+        """Generate identifiers for a given table."""
+        logger.debug(f'Starting join detection job for dataset {dataset_id}')
+        try:
+            job_id = self.client.create_join_detection_job(self.company_slug, dataset_id)
+            logger.debug(f'Join detection job with id {job_id} started for dataset {dataset_id}')
+        except RequestException as e:
+            if e.response is not None and e.response.status_code == requests.codes.not_found:
+                raise DatasetNotFoundException(dataset_id).extract_request_id(e)
+            raise JoinException(dataset_id).extract_request_id(e)
+
+        try:
+            state = self.client.wait_for_terminal_state(company_slug=self.company_slug, job_id=job_id, timeout=timeout)
+            if state != JobState.COMPLETED:
+                raise JoinException(dataset_id)
+
+            logger.debug(f'Join detection job with id {job_id} completed for dataset {dataset_id}')
+            return self.client.get_job_results(company_slug=self.company_slug, job_id=job_id)['joins']
+        except RequestException as e:
+            raise JoinException(dataset_id).extract_request_id(e)

--- a/src/panoramic/cli/state.py
+++ b/src/panoramic/cli/state.py
@@ -49,6 +49,10 @@ class ActionList(Generic[T]):
     def __init__(self, *, actions: List[Action[T]]):
         self.actions = actions
 
+    @property
+    def is_empty(self) -> bool:
+        return len(self.actions) == 0
+
 
 class VirtualState:
 

--- a/tests/panoramic/cli/join/test_client.py
+++ b/tests/panoramic/cli/join/test_client.py
@@ -1,0 +1,60 @@
+import pytest
+import responses
+
+from panoramic.cli.join.client import TERMINAL_STATES, JoinClient, JobState
+
+
+@pytest.fixture(autouse=True)
+def mock_token_url(monkeypatch):
+    monkeypatch.setenv('PANORAMIC_AUTH_TOKEN_URL', 'https://token')
+
+
+@responses.activate
+def test_create_identifier_job():
+    responses.add(responses.POST, 'https://token/', json={'access_token': '123123'})
+    responses.add(
+        responses.POST,
+        'https://joins/test-dataset?company_slug=test-company',
+        json={'data': {'job_id': 'test-job-id'}},
+    )
+
+    client = JoinClient(base_url='https://joins/', client_id='client-id', client_secret='client-secret')
+
+    assert client.create_join_detection_job('test-company', 'test-dataset') == 'test-job-id'
+
+
+@responses.activate
+def test_get_job_status():
+    responses.add(responses.POST, 'https://token/', json={'access_token': '123123'})
+    responses.add(responses.GET, 'https://joins/job/test-job-id', json={'data': {'status': 'RUNNING'}})
+
+    client = JoinClient(base_url='https://joins/', client_id='client-id', client_secret='client-secret')
+
+    assert client.get_job_status('test-job-id') == JobState.RUNNING
+
+
+#
+@responses.activate
+def test_get_job_results():
+    responses.add(responses.POST, 'https://token/', json={'access_token': '123123'})
+    responses.add(
+        responses.GET,
+        'https://joins/job/test-job-id',
+        json={'data': {'job_id': 'test-job-id', 'status': 'COMPLETED', 'joins': {}}},
+    )
+
+    client = JoinClient(base_url='https://joins/', client_id='client-id', client_secret='client-secret')
+
+    assert client.get_job_results('test-job-id') == {'job_id': 'test-job-id', 'status': 'COMPLETED', 'joins': {}}
+
+
+@responses.activate
+@pytest.mark.parametrize('final_state', TERMINAL_STATES)
+def test_wait_for_terminal_state(final_state):
+    responses.add(responses.POST, 'https://token/', json={'access_token': '123123'})
+    responses.add(responses.GET, 'https://joins/job/test-job-id', json={'data': {'status': 'RUNNING'}})
+    responses.add(responses.GET, 'https://joins/job/test-job-id', json={'data': {'status': final_state.value}})
+
+    client = JoinClient(base_url='https://joins/', client_id='client-id', client_secret='client-secret')
+
+    assert client.wait_for_terminal_state('test-job-id') == final_state

--- a/tests/panoramic/cli/join/test_client.py
+++ b/tests/panoramic/cli/join/test_client.py
@@ -10,7 +10,7 @@ def mock_token_url(monkeypatch):
 
 
 @responses.activate
-def test_create_identifier_job():
+def test_create_join_detection_job():
     responses.add(responses.POST, 'https://token/', json={'access_token': '123123'})
     responses.add(
         responses.POST,

--- a/tests/panoramic/cli/test_join_detector.py
+++ b/tests/panoramic/cli/test_join_detector.py
@@ -1,0 +1,52 @@
+from unittest.mock import Mock
+
+import pytest
+from requests.exceptions import RequestException
+
+from panoramic.cli.errors import JoinException
+from panoramic.cli.join.client import JobState, JoinClient
+from panoramic.cli.join_detector import JoinDetector
+
+
+def test_detect_joins_success():
+    mock_client = Mock(JoinClient, autospec=True)
+    detector = JoinDetector('test-company', client=mock_client)
+
+    mock_client.create_join_detection_job.return_value = 'test-job-id'
+    mock_client.wait_for_terminal_state.return_value = JobState.COMPLETED
+    mock_client.get_job_results.return_value = {'joins': {}}
+
+    assert {} == detector.detect('dataset')
+
+
+def test_detect_joins_job_creation_failed():
+    mock_client = Mock(JoinClient, autospec=True)
+    detector = JoinDetector('test-company', client=mock_client)
+
+    mock_client.create_join_detection_job.side_effect = RequestException('test')
+
+    with pytest.raises(JoinException):
+        detector.detect('dataset')
+
+
+def test_detect_joins_job_failed():
+    mock_client = Mock(JoinClient, autospec=True)
+    detector = JoinDetector('test-company', client=mock_client)
+
+    mock_client.create_join_detection_job.return_value = 'test-job-id'
+    mock_client.wait_for_terminal_state.return_value = JobState.FAILED
+
+    with pytest.raises(JoinException):
+        detector.detect('dataset')
+
+
+def test_generate_job_results_failed():
+    mock_client = Mock(JoinClient, autospec=True)
+    detector = JoinDetector('test--company', client=mock_client)
+
+    mock_client.create_join_detection_job.return_value = 'test-job-id'
+    mock_client.wait_for_terminal_state.return_value = JobState.COMPLETED
+    mock_client.get_job_results.side_effect = RequestException('test')
+
+    with pytest.raises(JoinException):
+        detector.detect('dataset')


### PR DESCRIPTION
This PR introduces new join detection features to the Panoramic CLI. All the http client boilerplate is added along with a CLI command that can be run against a locally defined dataset to suggest (or force override) joins between models in that dataset.