### PR TITLE
Send create_fields=true query param when upserting models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.1.3 Release
+
+- Send `create_fields` query param when upserting models
+
 ## Version 1.1.2 Release
 
 - Fix message shown when pushing/pulling models and datasets

--- a/src/panoramic/cli/__version__.py
+++ b/src/panoramic/cli/__version__.py
@@ -1,2 +1,2 @@
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __minimum_supported_version__ = "1.0.0"

--- a/src/panoramic/cli/model/client.py
+++ b/src/panoramic/cli/model/client.py
@@ -172,7 +172,7 @@ class ModelClient(OAuth2Client, VersionedClient):
     def upsert_model(self, data_source: str, company_slug: str, model: Model):
         """Add or update given model."""
         logger.debug(f'Upserting model with name: {model.model_name}')
-        params = {'virtual_data_source': data_source, 'company_slug': company_slug}
+        params = {'virtual_data_source': data_source, 'company_slug': company_slug, 'create_fields': 'true'}
         response = self.session.put(self.base_url, json=model.to_dict(), params=params, timeout=30)
         response.raise_for_status()
 

--- a/tests/panoramic/cli/model/test_client.py
+++ b/tests/panoramic/cli/model/test_client.py
@@ -47,7 +47,11 @@ def test_get_model_names():
 @responses.activate
 def test_upsert_model():
     responses.add(responses.POST, 'https://token/', json={'access_token': '123123'})
-    responses.add(responses.PUT, 'https://diesel/?virtual_data_source=test-source&company_slug=test-company', json={})
+    responses.add(
+        responses.PUT,
+        'https://diesel/?virtual_data_source=test-source&company_slug=test-company&create_fields=true',
+        json={},
+    )
 
     client = ModelClient(base_url='https://diesel/', client_id='client-id', client_secret='client-secret')
 


### PR DESCRIPTION
Preparing for fields files by sending this param for now and removing once we can manage fields separately.