### PR TITLE
Stop sending create_fields in Model client

### DIFF
--- a/src/panoramic/cli/model/client.py
+++ b/src/panoramic/cli/model/client.py
@@ -172,7 +172,7 @@ class ModelClient(OAuth2Client, VersionedClient):
     def upsert_model(self, data_source: str, company_slug: str, model: Model):
         """Add or update given model."""
         logger.debug(f'Upserting model with name: {model.model_name}')
-        params = {'virtual_data_source': data_source, 'company_slug': company_slug, 'create_fields': 'true'}
+        params = {'virtual_data_source': data_source, 'company_slug': company_slug}
         response = self.session.put(self.base_url, json=model.to_dict(), params=params, timeout=30)
         response.raise_for_status()
 

--- a/tests/panoramic/cli/model/test_client.py
+++ b/tests/panoramic/cli/model/test_client.py
@@ -48,9 +48,7 @@ def test_get_model_names():
 def test_upsert_model():
     responses.add(responses.POST, 'https://token/', json={'access_token': '123123'})
     responses.add(
-        responses.PUT,
-        'https://diesel/?virtual_data_source=test-source&company_slug=test-company&create_fields=true',
-        json={},
+        responses.PUT, 'https://diesel/?virtual_data_source=test-source&company_slug=test-company', json={},
     )
 
     client = ModelClient(base_url='https://diesel/', client_id='client-id', client_secret='client-secret')


### PR DESCRIPTION
This can be merged once we manage fields entirely via field files.