### PR TITLE
Fix field scan creating model files

### DIFF
--- a/src/panoramic/cli/local/writer.py
+++ b/src/panoramic/cli/local/writer.py
@@ -23,6 +23,7 @@ class FileWriter:
         if cwd is None:
             cwd = Path.cwd()
 
+        # TODO: bunch of methods below ignore self.cwd
         self.cwd = cwd
 
     def delete(self, actionable: Actionable):
@@ -82,7 +83,7 @@ class FileWriter:
 
     def write_scanned_field(self, field: PanoField):
         """"Write scanned field to local filesystem."""
-        path = Paths.scanned_fields_dir() / f'{field.slug}{FileExtension.MODEL_YAML.value}'
+        path = Paths.scanned_fields_dir() / f'{field.slug}{FileExtension.FIELD_YAML.value}'
         logger.debug(f'About to write field {field.slug}')
         write_yaml(path, field.to_dict())
 
@@ -125,9 +126,9 @@ class FileWriter:
         """Delete field from local filesystem."""
         assert field.file_name is not None
 
-        if field.data_source is not None:
+        if field.package is not None:
             # dataset-scope field
-            path = Paths.fields_dir(self.cwd / field.data_source) / field.file_name
+            path = Paths.fields_dir(self.cwd / field.package) / field.file_name
         else:
             # company-scope field
             path = Paths.fields_dir(self.cwd) / field.file_name

--- a/tests/panoramic/cli/local/test_writer.py
+++ b/tests/panoramic/cli/local/test_writer.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock, call, patch
 
 from panoramic.cli.local.writer import FileWriter
-from panoramic.cli.pano_model import PanoField
+from panoramic.cli.pano_model import PanoField, PanoModel
 from panoramic.cli.paths import FileExtension, PresetFileName, SystemDirectory
 
 
@@ -64,8 +64,8 @@ def test_writer_write_field(mock_write_yaml, tmp_path):
 @patch('panoramic.cli.local.writer.delete_file')
 def test_writer_delete_field(mock_delete_file, tmp_path):
     file_name = f'slug{FileExtension.FIELD_YAML.value}'
-    mock_field_company_scoped = Mock(spec=PanoField, slug='slug', data_source=None, file_name=file_name)
-    mock_field_vds_scoped = Mock(spec=PanoField, slug='slug', data_source='test_dataset', file_name=file_name)
+    mock_field_company_scoped = Mock(spec=PanoField, slug='slug', package=None, file_name=file_name)
+    mock_field_vds_scoped = Mock(spec=PanoField, slug='slug', package='test_dataset', file_name=file_name)
 
     FileWriter(cwd=tmp_path).delete_field(mock_field_company_scoped)
     FileWriter(cwd=tmp_path).delete_field(mock_field_vds_scoped)
@@ -73,4 +73,73 @@ def test_writer_delete_field(mock_delete_file, tmp_path):
     assert mock_delete_file.mock_calls == [
         call(tmp_path / SystemDirectory.FIELDS.value / file_name),
         call(tmp_path / 'test_dataset' / SystemDirectory.FIELDS.value / file_name),
+    ]
+
+
+@patch('panoramic.cli.local.writer.Paths')
+@patch('panoramic.cli.local.writer.write_yaml')
+def test_writer_write_scanned_model(mock_write_yaml, mock_paths, tmp_path):
+    mock_paths.scanned_dir.return_value = tmp_path
+    mock_model = Mock(spec=PanoModel, model_name='model')
+
+    FileWriter(cwd=tmp_path).write_scanned_model(mock_model)
+
+    assert mock_write_yaml.mock_calls == [
+        call(tmp_path / f'model{FileExtension.MODEL_YAML.value}', mock_model.to_dict())
+    ]
+
+
+@patch('panoramic.cli.local.writer.Paths')
+@patch('panoramic.cli.local.writer.write_yaml')
+def test_writer_write_scanned_field(mock_write_yaml, mock_paths, tmp_path):
+    mock_paths.scanned_fields_dir.return_value = tmp_path
+    mock_field = Mock(spec=PanoField, slug='slug')
+
+    FileWriter(cwd=tmp_path).write_scanned_field(mock_field)
+
+    assert mock_write_yaml.mock_calls == [
+        call(tmp_path / f'slug{FileExtension.FIELD_YAML.value}', mock_field.to_dict())
+    ]
+
+
+@patch('panoramic.cli.local.writer.Paths')
+def test_writer_write_empty_model(mock_paths, tmp_path):
+    mock_model = Mock(spec=PanoModel, model_name='model')
+
+    FileWriter(cwd=tmp_path).write_empty_model(mock_model)
+
+    assert (mock_paths.scanned_dir.return_value / f'model{FileExtension.MODEL_YAML.value}').touch.mock_calls == [call()]
+
+
+@patch('panoramic.cli.local.writer.Paths')
+def test_writer_write_empty_field(mock_paths, tmp_path):
+    mock_field = Mock(spec=PanoField, slug='slug')
+
+    FileWriter(cwd=tmp_path).write_empty_field(mock_field)
+
+    assert (mock_paths.scanned_fields_dir.return_value / f'model{FileExtension.FIELD_YAML.value}').touch.mock_calls == [
+        call()
+    ]
+
+
+@patch('panoramic.cli.local.writer.delete_file')
+def test_writer_delete_model(mock_delete_file, tmp_path):
+    file_name = f'model{FileExtension.FIELD_YAML.value}'
+    mock_model = Mock(spec=PanoModel, model_name='model', package='package', file_name=file_name)
+
+    FileWriter(cwd=tmp_path).delete_model(mock_model)
+
+    assert mock_delete_file.mock_calls == [
+        call(tmp_path / 'package' / file_name),
+    ]
+
+
+@patch('panoramic.cli.local.writer.write_yaml')
+def test_writer_write_model(mock_write_yaml, tmp_path):
+    mock_model = Mock(spec=PanoModel, model_name='model', virtual_data_source='test_dataset')
+
+    FileWriter(cwd=tmp_path).write_model(mock_model)
+
+    assert mock_write_yaml.mock_calls == [
+        call(tmp_path / 'test_dataset' / f'model{FileExtension.MODEL_YAML.value}', mock_model.to_dict()),
     ]


### PR DESCRIPTION
There's a bug in scan command where we create field files with `.model.yaml` suffix