### PR TITLE
Fix global help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.3.2 Release
+
+- Update README and global help for pano command
+
 ## Version 1.3.1 Release
 
 - Fix scanned field files having model suffix

--- a/README.md
+++ b/README.md
@@ -30,19 +30,22 @@ Options:
 
 Commands:
   configure         Configure pano CLI options
+  detect-joins      Detect joins under a dataset
+  field             Commands on local field files.
   init              Initialize metadata repository
   list-companies    List available companies
   list-connections  List available data connections
   pull              Pull models from remote
   push              Push models to remote
   scan              Scan models from source
+  validate          Validate local files
 ```
 
 ## Release process
 
 To release a new version of the library, follow these steps:
 
-* In your PR, update version in [setup.py](setup.py) and add entry to [CHANGELOG.md](CHANGELOG.md)
+* In your PR, update version in [__version__.py](src/panoramic/cli/__version__.py) and add entry to [CHANGELOG.md](CHANGELOG.md)
 * After merge, tag the commit with version number from setup.py. For example `git tag v0.1.1`.
 * Once the tag is pushed, it will trigger a build with Travis, which will publish the new version on PyPI.
 

--- a/src/panoramic/cli/__version__.py
+++ b/src/panoramic/cli/__version__.py
@@ -1,2 +1,2 @@
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 __minimum_supported_version__ = "1.3.1"

--- a/src/panoramic/cli/cli.py
+++ b/src/panoramic/cli/cli.py
@@ -78,7 +78,7 @@ class LocalStateAwareCommand(ContextAwareCommand):
         return super().invoke(ctx)
 
 
-@click.group(context_settings={'help_option_names': ["-h", "--help"]})
+@click.group(context_settings={'help_option_names': ["-h", "--help"]}, help='')
 @click.option('--debug', is_flag=True, help='Enables debug mode')
 @click.version_option(__version__)
 @handle_exception


### PR DESCRIPTION
Without `help=''`, click takes the docstring from the `cli` `Group` as the description of the CLI tool.