### PR TITLE
Publish versioned homebrew formulas

### DIFF
--- a/shipping/string_to_class.rb
+++ b/shipping/string_to_class.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+def class_s(name)
+    class_name = name.capitalize
+    class_name.gsub!(/[-_.\s]([a-zA-Z0-9])/) { Regexp.last_match(1).upcase }
+    class_name.tr!("+", "x")
+    class_name.sub!(/(.)@(\d)/, "\\1AT\\2")
+    class_name
+end
+
+def str_to_class(name)
+    mod = Module.new
+    class_name = class_s(name)
+    class_name
+end
+
+if ARGV.length == 1
+    puts str_to_class(ARGV[0])
+else
+    raise("Invalid number of arguments, should only be 1")
+end

--- a/shipping/update_homebrew.sh
+++ b/shipping/update_homebrew.sh
@@ -24,7 +24,9 @@ update_homebrew_formula() {
   IS_PRERELEASE=$(python -c 'import packaging.version as v;import os;print(v.parse(os.environ["PACKAGE_VERSION"]).is_prerelease)')
 
   rm -fr .homebrew_repo/Formula/panoramic-cli@"$PACKAGE_VERSION".rb
-  cp brewout/panoramic-cli.rb .homebrew_repo/Formula/panoramic-cli@"$PACKAGE_VERSION".rb
+  CLASS_NAME=$(ruby shipping/string_to_class.rb panoramic-cli@"$PACKAGE_VERSION")
+  echo $CLASS_NAME
+  sed -e "s/PanoramicCli/$CLASS_NAME/" brewout/panoramic-cli.rb > .homebrew_repo/Formula/panoramic-cli@"$PACKAGE_VERSION".rb
 
   if [[ "$IS_PRERELEASE" == "False" ]]; then
     rm -fr .homebrew_repo/Formula/panoramic-cli.rb
@@ -33,6 +35,7 @@ update_homebrew_formula() {
 
   cd .homebrew_repo
   git add Formula/panoramic-cli@"$PACKAGE_VERSION".rb
+
   if [[ "$IS_PRERELEASE" == "False" ]]; then
     git add Formula/panoramic-cli.rb
   fi


### PR DESCRIPTION
Update the Homebrew script to create version formulas and only update the main formula on a normal release. This relies on PEP 440 to define what a "prerelease" is.