### PR TITLE
Deprecate field_type Field attribute

### DIFF
--- a/src/panoramic/cli/errors.py
+++ b/src/panoramic/cli/errors.py
@@ -348,7 +348,7 @@ class MissingFieldFileError(ValidationError):
     dataset_slug: str
     data_source: str
     data_reference: str
-    identifier: bool
+    identifier: bool  # FIXME: might not be used anymore
 
     def __init__(
         self,

--- a/src/panoramic/cli/field/client.py
+++ b/src/panoramic/cli/field/client.py
@@ -51,7 +51,6 @@ class Field:
     group: str
     display_name: str
     data_type: str
-    field_type: str
     description: Optional[str]
     data_source: Optional[str]
     calculation: Optional[str]
@@ -65,7 +64,6 @@ class Field:
         group: str,
         display_name: str,
         data_type: str,
-        field_type: str,
         description: Optional[str],
         data_source: Optional[str],
         calculation: Optional[str],
@@ -76,7 +74,6 @@ class Field:
         self.group = group
         self.display_name = display_name
         self.data_type = data_type
-        self.field_type = field_type
         self.description = description
         self.data_source = data_source
         self.calculation = calculation
@@ -91,7 +88,6 @@ class Field:
             group=inputs['group'],
             display_name=inputs['display_name'],
             data_type=inputs['data_type'],
-            field_type=inputs['field_type'],
             description=inputs.get('description'),
             data_source=inputs.get('data_source'),
             aggregation=Aggregation.from_dict(aggregation) if aggregation is not None else None,
@@ -105,7 +101,6 @@ class Field:
             'group': self.group,
             'display_name': self.display_name,
             'data_type': self.data_type,
-            'field_type': self.field_type,
             'description': self.description,
             'calculation': self.calculation,
             'aggregation': self.aggregation.to_dict() if self.aggregation is not None else None,
@@ -120,7 +115,6 @@ class Field:
                 self.group,
                 self.display_name,
                 self.data_type,
-                self.field_type,
                 self.description,
                 self.data_source,
                 self.calculation,

--- a/src/panoramic/cli/field_mapper.py
+++ b/src/panoramic/cli/field_mapper.py
@@ -16,7 +16,6 @@ def map_field_from_remote(field: Field) -> PanoField:
         group=field.group,
         display_name=field.display_name,
         data_type=field.data_type,
-        field_type=field.field_type,
         description=field.description,
         data_source=data_source,
         aggregation=field.aggregation,
@@ -48,7 +47,6 @@ def map_field_from_local(field: PanoField) -> Field:
         group=field.group,
         display_name=field.display_name,
         data_type=field.data_type,
-        field_type=field.field_type,
         description=field.description,
         data_source=field.data_source,
         aggregation=field.aggregation,
@@ -61,18 +59,15 @@ def map_column_to_field(
     column: Dict[str, Any],
     slug: str,
     data_source: str,
-    is_identifier: bool = False,
 ) -> PanoField:
     aggregation = (
         Aggregation(type=column['aggregation_type'], params=None)
         if column.get('aggregation_type') is not None
         else None
     )
-    field_type = 'dimension' if is_identifier else column['taxon_type']
 
     return PanoField(
         slug=slug,
-        field_type=field_type,
         data_source=data_source,
         display_name=slug,
         group='CLI',
@@ -84,7 +79,6 @@ def map_column_to_field(
 def map_error_to_field(error: MissingFieldFileError) -> PanoField:
     return PanoField(
         slug=error.field_slug,
-        field_type='dimension' if error.identifier else 'TODO: add field_type',
         data_source=error.dataset_slug,
         display_name=error.field_slug,
         group='CLI',

--- a/src/panoramic/cli/pano_model.py
+++ b/src/panoramic/cli/pano_model.py
@@ -76,7 +76,6 @@ class PanoField(Actionable):
     group: str
     display_name: str
     data_type: str
-    field_type: str
     description: Optional[str]
     data_source: Optional[str]
     calculation: Optional[str]
@@ -90,7 +89,6 @@ class PanoField(Actionable):
         group: str,
         display_name: str,
         data_type: str,
-        field_type: str,
         description: Optional[str] = None,
         data_source: Optional[str] = None,
         calculation: Optional[str] = None,
@@ -104,7 +102,6 @@ class PanoField(Actionable):
         self.group = group
         self.display_name = display_name
         self.data_type = data_type
-        self.field_type = field_type
         self.description = description
         self.data_source = data_source
         self.calculation = calculation
@@ -124,7 +121,6 @@ class PanoField(Actionable):
             'group': self.group,
             'display_name': self.display_name,
             'data_type': self.data_type,
-            'field_type': self.field_type,
             'data_source': self.data_source,
         }
 
@@ -147,7 +143,6 @@ class PanoField(Actionable):
             group=inputs['group'],
             display_name=inputs['display_name'],
             data_type=inputs['data_type'],
-            field_type=inputs['field_type'],
             description=inputs.get('description'),
             data_source=inputs.get('data_source'),
             aggregation=Aggregation.from_dict(aggregation) if aggregation is not None else None,
@@ -171,7 +166,6 @@ class PanoField(Actionable):
                 self.group,
                 self.display_name,
                 self.data_type,
-                self.field_type,
                 self.description,
                 self.data_source,
                 self.calculation,

--- a/src/panoramic/cli/scan.py
+++ b/src/panoramic/cli/scan.py
@@ -115,7 +115,6 @@ def scan_fields_for_errors(errors: Sequence[MissingFieldFileError]) -> List[Pano
                             column,
                             slug=error.field_slug,
                             data_source=error.dataset_slug,
-                            is_identifier=error.identifier,
                         )
                     )
                 del errors_by_column[data_source, data_reference]

--- a/src/panoramic/cli/schemas/field.schema.json
+++ b/src/panoramic/cli/schemas/field.schema.json
@@ -31,7 +31,8 @@
     },
     "field_type": {
       "description": "Type of field",
-      "type": "string"
+      "type": "string",
+      "deprecated": true
     },
     "description": {
       "description": "Free text describing the field",
@@ -68,7 +69,6 @@
     "slug",
     "group",
     "display_name",
-    "data_type",
-    "field_type"
+    "data_type"
   ]
 }

--- a/src/panoramic/cli/validate.py
+++ b/src/panoramic/cli/validate.py
@@ -139,6 +139,16 @@ def _validate_package_models(package: FilePackage) -> Tuple[List[PanoModel], Lis
     return models, errors
 
 
+def _check_field_deprecations(data: Dict[str, Any], path: Path) -> List[DeprecatedAttributeWarning]:
+    """Check for deprecated attributes in a field."""
+    errors = []
+    has_field_type_defined = 'field_type' in data.keys()
+    if has_field_type_defined:
+        errors.append(DeprecatedAttributeWarning(attribute='field_type', path=path))
+
+    return errors
+
+
 def _validate_package_fields(
     package: Union[FilePackage, GlobalPackage]
 ) -> Tuple[List[PanoField], List[ValidationError]]:
@@ -151,6 +161,8 @@ def _validate_package_fields(
             field = PanoField.from_dict(field_data)
             fields.append(field)
             field_paths_by_id[(field.data_source, field.slug)].append(field_path)
+
+            errors.extend(_check_field_deprecations(field_data, field_path))
         except InvalidYamlFile as e:
             errors.append(e)
         except JsonSchemaValidationError as e:

--- a/tests/panoramic/cli/test_field_mapper.py
+++ b/tests/panoramic/cli/test_field_mapper.py
@@ -15,7 +15,6 @@ from panoramic.cli.pano_model import PanoField
 def dummy_local_field() -> PanoField:
     data = dict(
         slug='slug',
-        field_type='field_type',
         group='group',
         display_name='Display name',
         data_type='data_type',
@@ -28,7 +27,6 @@ def dummy_local_field() -> PanoField:
 def dummy_remote_field() -> Field:
     data = dict(
         slug='slug',
-        field_type='field_type',
         group='group',
         display_name='Display name',
         data_type='data_type',
@@ -78,7 +76,6 @@ def test_map_column_to_field_basic():
     assert actual == PanoField(
         slug='field_slug',
         data_source='data_source',
-        field_type='dimension',
         group='CLI',
         display_name='field_slug',
         data_type='text',
@@ -101,37 +98,11 @@ def test_map_column_to_field_aggregation():
     )
     assert actual == PanoField(
         slug='field_slug',
-        field_type='metric',
         group='CLI',
         data_source='data_source',
         display_name='field_slug',
         data_type='numeric',
         aggregation=Aggregation(type='sum', params=None),
-    )
-
-
-def test_map_column_to_field_identifier():
-    actual = map_column_to_field(
-        {
-            'column_name': 'slug',
-            'data_type': 'TEXT',
-            'taxon_type': 'metric',
-            'field_map': ['slug'],
-            'data_reference': '"slug"',
-            'aggregation_type': None,
-            'validation_type': 'text',
-        },
-        slug='field_slug',
-        data_source='data_source',
-        is_identifier=True,
-    )
-    assert actual == PanoField(
-        slug='field_slug',
-        data_source='data_source',
-        field_type='dimension',
-        group='CLI',
-        display_name='field_slug',
-        data_type='text',
     )
 
 
@@ -150,5 +121,4 @@ def test_map_error_to_field():
         display_name='test_field',
         group='CLI',
         data_type='TODO: add data_type',
-        field_type='TODO: add field_type',
     )

--- a/tests/panoramic/cli/test_validate.py
+++ b/tests/panoramic/cli/test_validate.py
@@ -656,7 +656,7 @@ def test_validate_local_state_deprecated_attribute(tmp_path, monkeypatch):
     errors = validate_local_state()
     assert errors == [
         DeprecatedAttributeWarning(attribute='data_type', path=dataset_dir / 'test_model.model.yaml'),
-        DeprecatedAttributeWarning(attribute='field_type', path=dataset_dir / 'test_field.field.yaml'),
+        DeprecatedAttributeWarning(attribute='field_type', path=dataset_dir / 'fields' / 'test_field.field.yaml'),
     ]
 
 

--- a/tests/panoramic/cli/test_validate.py
+++ b/tests/panoramic/cli/test_validate.py
@@ -190,7 +190,6 @@ VALID_FIELD_MINIMAL: Dict[str, Any] = {
     'group': 'group',
     'display_name': 'Display name',
     'data_type': 'data_type',
-    'field_type': 'field_type',
 }
 
 VALID_FIELD_FULL: Dict[str, Any] = {
@@ -198,7 +197,6 @@ VALID_FIELD_FULL: Dict[str, Any] = {
     'group': 'group',
     'display_name': 'Full display name',
     'data_type': 'data_type',
-    'field_type': 'field_type',
     'calculation': 'calculation',
     'aggregation': {'type': 'sum'},
     'display_format': 'display_format',
@@ -394,8 +392,6 @@ INVALID_FIELDS = [
     {**VALID_FIELD_MINIMAL, 'slug': 123},
     # group not set
     {k: v for k, v in VALID_FIELD_MINIMAL.items() if k != 'group'},
-    # field_type not set
-    {k: v for k, v in VALID_FIELD_MINIMAL.items() if k != 'field_type'},
     # data_type not set
     {k: v for k, v in VALID_FIELD_MINIMAL.items() if k != 'data_type'},
     # typo in api_version
@@ -655,10 +651,13 @@ def test_validate_local_state_deprecated_attribute(tmp_path, monkeypatch):
 
     Paths.fields_dir(dataset_dir).mkdir()
     with (Paths.fields_dir(dataset_dir) / 'test_field.field.yaml').open('w') as f:
-        f.write(yaml.dump(VALID_FIELD_MINIMAL))
+        f.write(yaml.dump({**VALID_FIELD_MINIMAL, 'field_type': 'field_type'}))
 
     errors = validate_local_state()
-    assert errors == [DeprecatedAttributeWarning(attribute='data_type', path=dataset_dir / 'test_model.model.yaml')]
+    assert errors == [
+        DeprecatedAttributeWarning(attribute='data_type', path=dataset_dir / 'test_model.model.yaml'),
+        DeprecatedAttributeWarning(attribute='field_type', path=dataset_dir / 'test_field.field.yaml'),
+    ]
 
 
 def test_validate_local_state_orphan_field_files(tmp_path, monkeypatch):


### PR DESCRIPTION
This PR removes field type from the field YAML definition and stops propagating it from the API. A validation warning is added to highlight this change on an existing pano repo, but bear in mind, that  `pano pull` will reflect the change on the first pull after the update.