### PR TITLE
Detect time granularity from models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,13 @@ pre-commit-install:
 lint:
 	pre-commit run --all-files
 
-test:
-	python -m pytest tests e2e -vv
+test: unit_test e2e
 
 e2e:
-	python -m pytest e2e
+	PYTHONPATH=$(shell pwd)/src python -m pytest e2e
 
 unit_test:
-	python -m pytest tests
+	PYTHONPATH=$(shell pwd)/src python -m pytest tests
 
 black:
 	pre-commit run black

--- a/src/panoramic/cli/husky/core/model/models.py
+++ b/src/panoramic/cli/husky/core/model/models.py
@@ -1,13 +1,11 @@
 from typing import Dict, List, Optional, Set
 
-from panoramic.cli.husky.service.constants import TaxonSlugs
-
-from panoramic.cli.husky.core.federated.utils import prefix_with_virtual_data_source
 from schematics.types import BooleanType, DictType, ListType, ModelType, StringType
 
 from panoramic.cli.husky.common.exception_enums import ExceptionErrorCode
 from panoramic.cli.husky.common.my_memoize import memoized_property
 from panoramic.cli.husky.common.util import serialize_class_with_props
+from panoramic.cli.husky.core.federated.utils import prefix_with_virtual_data_source
 from panoramic.cli.husky.core.model.enums import (
     HuskyModelType,
     JoinDirection,
@@ -25,6 +23,7 @@ from panoramic.cli.husky.core.schematics.model import (
 )
 from panoramic.cli.husky.core.sql_alchemy_util import compile_query, quote_identifier
 from panoramic.cli.husky.core.tel.tel_dialect import ModelTelDialect
+from panoramic.cli.husky.service.constants import TaxonSlugs
 from panoramic.cli.husky.service.context import (
     SNOWFLAKE_HUSKY_CONTEXT,
     HuskyQueryContext,

--- a/src/panoramic/cli/husky/service/model_retriever/model_augments.py
+++ b/src/panoramic/cli/husky/service/model_retriever/model_augments.py
@@ -1,6 +1,5 @@
 from typing import Dict, List
 
-from panoramic.cli.husky.core.federated.utils import prefix_with_virtual_data_source
 from panoramic.cli.husky.core.model.enums import TimeGranularity
 from panoramic.cli.husky.core.model.models import (
     AttributeNotFound,
@@ -76,22 +75,12 @@ class ModelAugments:
     def _model_add_time_attributes(cls, model: HuskyModel):
         try:
             time_attrs: List[ModelAttribute] = []
-            date_taxon_slug = prefix_with_virtual_data_source(model.data_source, TaxonSlugs.DATE)
-            date_hour_taxon_slug = prefix_with_virtual_data_source(model.data_source, TaxonSlugs.DATE_HOUR)
 
-            if (
-                model.time_granularity
-                and model.time_granularity is TimeGranularity.day
-                and model.has_taxon(date_taxon_slug)
-            ):
+            if model.time_granularity is TimeGranularity.day:
                 time_attrs = ModelAugments._prepare_derived_time_attributes(
                     TaxonSlugs.DATE, ModelAugments._model_attributes_day
                 )
-            elif (
-                model.time_granularity
-                and model.time_granularity == TimeGranularity.hour
-                and model.has_taxon(date_hour_taxon_slug)
-            ):
+            elif model.time_granularity is TimeGranularity.hour:
                 # Hourly models should always have date_hour attribute. This is correct.
                 time_attrs = ModelAugments._prepare_derived_time_attributes(
                     TaxonSlugs.DATE_HOUR,

--- a/tests/panoramic/cli/husky/core/federated/model/mappers_test.py
+++ b/tests/panoramic/cli/husky/core/federated/model/mappers_test.py
@@ -172,7 +172,6 @@ def test_api_model_to_internal(api_model):
         'data_sources': [_VIRTUAL_DATA_SOURCE],
         'fully_qualified_name_parts': api_model.data_source.split('.'),
         'model_type': 'metric',
-        'time_granularity': None,
         'attributes': {
             attr.taxon: attr.to_primitive()
             for api_attr in api_model.attributes

--- a/tests/panoramic/cli/husky/service/model_retriever/model_retriever_test.py
+++ b/tests/panoramic/cli/husky/service/model_retriever/model_retriever_test.py
@@ -1,7 +1,7 @@
 import datetime
 from unittest.mock import patch
 
-from panoramic.cli.husky.core.model.enums import ModelVisibility, TimeGranularity
+from panoramic.cli.husky.core.model.enums import ModelVisibility
 from panoramic.cli.husky.service.model_retriever.component import ModelRetriever
 from panoramic.cli.husky.service.types.api_scope_types import Scope
 from tests.panoramic.cli.husky.test.mocks.husky_model import generate_husky_mock_model
@@ -43,7 +43,6 @@ mock_response = [
         visibility=ModelVisibility.available,
         company_id='company_2',
         project_id='project_2',
-        time_granularity=TimeGranularity.hour,
     ),
     generate_husky_mock_model(
         name='appnexus_model',

--- a/tests/panoramic/cli/husky/test/mocks/husky_model.py
+++ b/tests/panoramic/cli/husky/test/mocks/husky_model.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Optional
 
-from panoramic.cli.husky.core.model.enums import ModelVisibility, TimeGranularity
+from panoramic.cli.husky.core.model.enums import ModelVisibility
 from panoramic.cli.husky.core.model.models import HuskyModel, ModelJoin
 from panoramic.cli.husky.service.model_retriever.model_augments import ModelAugments
 
@@ -191,8 +191,8 @@ def get_mock_metric_time_taxon_model() -> HuskyModel:
                 'mock_data_source|date': dict(
                     tel_transformation='"date"', taxon='mock_data_source|date', identifier=True
                 ),
+                f'{MOCK_DATA_SOURCE_NAME}|date': dict(tel_transformation='"date"', taxon=f'{MOCK_DATA_SOURCE_NAME}|date', identifier=False),
             },
-            time_granularity=TimeGranularity.day,
             data_sources=[MOCK_DATA_SOURCE_NAME],
             joins=[
                 ModelJoin(

--- a/tests/panoramic/cli/husky/test/mocks/husky_model.py
+++ b/tests/panoramic/cli/husky/test/mocks/husky_model.py
@@ -191,7 +191,9 @@ def get_mock_metric_time_taxon_model() -> HuskyModel:
                 'mock_data_source|date': dict(
                     tel_transformation='"date"', taxon='mock_data_source|date', identifier=True
                 ),
-                f'{MOCK_DATA_SOURCE_NAME}|date': dict(tel_transformation='"date"', taxon=f'{MOCK_DATA_SOURCE_NAME}|date', identifier=False),
+                f'{MOCK_DATA_SOURCE_NAME}|date': dict(
+                    tel_transformation='"date"', taxon=f'{MOCK_DATA_SOURCE_NAME}|date', identifier=False
+                ),
             },
             data_sources=[MOCK_DATA_SOURCE_NAME],
             joins=[


### PR DESCRIPTION
- fixed running tests from makefile
- allow Husky to detect TimeGranularity from taxons on models (instead of forcing the value)