### PR TITLE
Remove data_type and column_sql_type from model attribute (deprecated)

### DIFF
--- a/e2e/panoramic/cli/test_field_scaffold_e2e.py
+++ b/e2e/panoramic/cli/test_field_scaffold_e2e.py
@@ -22,23 +22,24 @@ def test_field_scaffold_e2e(_, clear_fields):
     runner = CliRunner()
     result = runner.invoke(cli, ['field', 'scaffold', '-y'])
 
-    # fields_dir
+    fields_dir = Paths.fields_dir(Path('test_dataset'))
     Paths.fields_dir(Path('test_dataset'))
 
     assert result.exit_code == 0
-    # TODO uncomment once scaffold starts working
 
-
-#     assert {f.name for f in fields_dir.iterdir()} == {'dataset_test_field.field.yaml'}
-#     assert (
-#         (fields_dir / 'dataset_test_field.field.yaml').read_text()
-#         == """api_version: v1
-# display_name: dataset_test_field
-# field_type: dimension
-# group: CLI
-# slug: dataset_test_field
-# """
-#     )
+    assert {f.name for f in fields_dir.iterdir()} == {'dataset_test_field.field.yaml'}
+    assert (
+        (fields_dir / 'dataset_test_field.field.yaml').read_text()
+        == """aggregation:
+  type: group_by
+api_version: v1
+data_type: text
+display_name: dataset_test_field
+field_type: dimension
+group: CLI
+slug: dataset_test_field
+"""
+    )
 
 
 @patch('panoramic.cli.command.scaffold_missing_fields')

--- a/e2e/panoramic/cli/test_field_scaffold_e2e.py
+++ b/e2e/panoramic/cli/test_field_scaffold_e2e.py
@@ -33,7 +33,6 @@ def test_field_scaffold_e2e(_, clear_fields):
 #     assert (
 #         (fields_dir / 'dataset_test_field.field.yaml').read_text()
 #         == """api_version: v1
-# data_type: text
 # display_name: dataset_test_field
 # field_type: dimension
 # group: CLI

--- a/src/panoramic/cli/husky/core/enums.py
+++ b/src/panoramic/cli/husky/core/enums.py
@@ -2,44 +2,6 @@ from enum import Enum
 from typing import Set
 
 
-class DbDataType(str, Enum):
-    """
-    Data types in database engines
-    """
-
-    BOOLEAN = 'BOOLEAN'
-    SMALLINT = 'SMALLINT'
-    INTEGER = 'INTEGER'
-    BIGINT = 'BIGINT'
-    TINYINT = 'TINYINT'
-
-    FLOAT = 'FLOAT'
-    DOUBLE = 'DOUBLE'
-    DECIMAL = 'DECIMAL'
-
-    CHARACTER_VARYING = 'CHARACTER VARYING'
-    CHARACTER = 'CHARACTER'
-    NATIONAL_CHARACTER_VARYING = 'NATIONAL CHARACTER VARYING'
-    NATIONAL_CHARACTER = 'NATIONAL CHARACTER'
-    BINARY_VARYING = 'BINARY VARYING'
-    BINARY = 'BINARY'
-
-    DATE = 'DATE'
-    TIME = 'TIME'
-    TIME_WITH_TIME_ZONE = 'TIME WITH TIME ZONE'
-    TIMESTAMP = 'TIMESTAMP'
-    TIMESTAMP_WITH_TIME_ZONE = 'TIMESTAMP WITH TIME ZONE'
-    INTERVAL_YEAR_TO_MONTH = 'INTERVAL YEAR TO MONTH'
-    INTERVAL_DAY_TO_SECOND = 'INTERVAL DAY TO SECOND'
-    INTERVAL = 'INTERVAL'
-
-    MAP = 'MAP'
-    ANY = 'ANY'
-    NULL = 'NULL'
-    UNION = 'UNION'
-    JAVA_OBJECT = 'JAVA_OBJECT'
-
-
 class DbTimeUnit(str, Enum):
     """
     Enum with valid time units

--- a/src/panoramic/cli/husky/core/federated/model/mappers.py
+++ b/src/panoramic/cli/husky/core/federated/model/mappers.py
@@ -1,8 +1,6 @@
 from collections import defaultdict
 from typing import Dict, List, Set
 
-from panoramic.cli.husky.common.enum import EnumHelper
-from panoramic.cli.husky.core.enums import DbDataType
 from panoramic.cli.husky.core.federated.model.models import (
     FdqModel,
     FdqModelAttribute,
@@ -34,13 +32,10 @@ class FdqModelAttributeMapper:
         and cutoff virtual data source from taxon slug, if needed
         """
         # type is same across all attributes
-        data_type = model_attributes[0].column_sql_type
-
         return FdqModelAttribute.construct(
             field_map=[remove_virtual_data_source_prefix(virtual_data_source, attr.taxon) for attr in model_attributes],
             # for backward compatibility, we reuse column_name for a bit
             data_reference=transformation,
-            data_type=EnumHelper.from_value_safe(DbDataType, data_type),
         )
 
     @classmethod
@@ -59,7 +54,6 @@ class FdqModelAttributeMapper:
                         'tel_transformation': attr.data_reference,
                         'taxon': prefix_with_virtual_data_source(virtual_data_source, taxon_slug).lower(),
                         'identifier': taxon_slug in identifiers,
-                        'column_sql_type': None if attr.data_type is None else attr.data_type.value,
                     }
                 )
             )

--- a/src/panoramic/cli/husky/core/federated/model/models.py
+++ b/src/panoramic/cli/husky/core/federated/model/models.py
@@ -1,11 +1,10 @@
 from collections import Counter
 from enum import Enum
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Set
 
 from pydantic import Field, root_validator
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
 
-from panoramic.cli.husky.core.enums import DbDataType
 from panoramic.cli.husky.core.federated.model.tel.data_structures import (
     AttributeValidationTelVisitorParams,
 )
@@ -26,11 +25,6 @@ class FdqModelJoinRelationship(Enum):
 
 
 class FdqModelAttribute(PydanticModel):
-    data_type: Optional[DbDataType]
-    """
-    Type of the column this attribute points to.
-    """
-
     data_reference: str = Field(..., min_length=1)
     """
     Transformation applied to the model attribute

--- a/src/panoramic/cli/husky/core/model/models.py
+++ b/src/panoramic/cli/husky/core/model/models.py
@@ -39,11 +39,6 @@ class ModelAttribute(SchematicsModel):
 
     quantity_type: ValueQuantityType = EnumType(ValueQuantityType, default=ValueQuantityType.scalar)
 
-    column_sql_type: Optional[str] = NonEmptyStringType(default=None)
-    """
-    Type of the column this attribute points to.
-    """
-
     @memoized_property
     def taxon_memoized(self):
         """

--- a/src/panoramic/cli/husky/core/taxonomy/aggregations.py
+++ b/src/panoramic/cli/husky/core/taxonomy/aggregations.py
@@ -93,21 +93,14 @@ class AggregationDefinition(PydanticModel):
         if values['type'] == AggregationType.not_set or values['type'] in cls._SIMPLE_AGGS:
             values['params'] = None
             return values
-        elif agg_type == AggregationType.count_distinct.value:
-            if 'params' not in values or values['params'] is None:
-                # this is a temporary solution for FE
-                # TODO: remove this once FE starts using field "aggregation" instead of field "aggregation_type"
-                values['params'] = AggregationParamsCountDistinct()
-            else:
-                values['params'] = AggregationParamsCountDistinct(**values['params'])
-
-            return values
 
         if 'params' not in values:
             raise ValueError('Missing "params" field')
 
         if agg_type in cls._WITH_SORT_DIMENSION_AGGS:
             values['params'] = AggregationParamsSortDimension(**values['params'])
+        elif agg_type == AggregationType.count_distinct.value:
+            values['params'] = AggregationParamsCountDistinct(**values['params'])
         else:
             raise ValueError(f'Unsupported aggregation type - {values["type"]}')
 

--- a/src/panoramic/cli/schemas/model.schema.json
+++ b/src/panoramic/cli/schemas/model.schema.json
@@ -68,11 +68,6 @@
                     "items": {
                         "type": "string"
                     }
-                },
-                "data_type": {
-                    "type": "string",
-                    "description": "SQL type of the attribute (deprecated)",
-                    "deprecated": true
                 }
             },
             "required": [

--- a/src/panoramic/cli/validate.py
+++ b/src/panoramic/cli/validate.py
@@ -65,14 +65,8 @@ class JsonSchemas:
 
 def _check_model_deprecations(data: Dict[str, Any], path: Path) -> List[DeprecatedAttributeWarning]:
     """Check for deprecated attributes in a model."""
-    errors = []
 
-    fields: List[Dict[str, Any]] = data.get('fields', [])
-    contains_data_type = any('data_type' in f for f in fields)
-    if contains_data_type:
-        errors.append(DeprecatedAttributeWarning(attribute='data_type', path=path))
-
-    return errors
+    return []
 
 
 def _check_properties_deprecations(fp: Path, schema: Dict[str, Any]):

--- a/tests/panoramic/cli/husky/core/federated/model/mappers_test.py
+++ b/tests/panoramic/cli/husky/core/federated/model/mappers_test.py
@@ -1,6 +1,5 @@
 import pytest
 
-from panoramic.cli.husky.core.enums import DbDataType
 from panoramic.cli.husky.core.federated.model.mappers import (
     FdqModelAttributeMapper,
     FdqModelJoinMapper,
@@ -37,7 +36,6 @@ _USER_ID = 'usr-id'
             [
                 ModelAttribute(
                     {
-                        'column_sql_type': DbDataType.CHARACTER_VARYING,
                         'tel_transformation': '"another_col"',
                         'taxon': f'{_VIRTUAL_DATA_SOURCE}|taxon_slug',
                     }
@@ -49,7 +47,6 @@ _USER_ID = 'usr-id'
             [
                 ModelAttribute(
                     {
-                        'column_sql_type': DbDataType.SMALLINT,
                         'tel_transformation': '"col_name"',
                         'taxon': f'{_VIRTUAL_DATA_SOURCE}|taxon_slug_2',
                     }
@@ -62,7 +59,6 @@ def test_api_model_attribute_from_internal(transformation, model_attrs):
     attr = FdqModelAttributeMapper.from_internal(transformation, model_attrs, _VIRTUAL_DATA_SOURCE)
 
     assert attr.dict(by_alias=True) == {
-        'data_type': model_attrs[0].column_sql_type,
         'data_reference': transformation,
         'field_map': [remove_virtual_data_source_prefix(_VIRTUAL_DATA_SOURCE, model_attrs[0].taxon)],
     }
@@ -71,8 +67,8 @@ def test_api_model_attribute_from_internal(transformation, model_attrs):
 @pytest.mark.parametrize(
     'model_attr',
     [
-        FdqModelAttribute(data_type=DbDataType.DATE, data_reference='"first_col"', field_map=['taxon_slug']),
-        FdqModelAttribute(data_type=DbDataType.INTEGER, data_reference='"col_name"', field_map=['taxon_slug_2']),
+        FdqModelAttribute(data_reference='"first_col"', field_map=['taxon_slug']),
+        FdqModelAttribute(data_reference='"col_name"', field_map=['taxon_slug_2']),
     ],
 )
 def test_api_model_attribute_to_internal(model_attr):
@@ -81,7 +77,6 @@ def test_api_model_attribute_to_internal(model_attr):
 
     assert [attr.to_primitive() for attr in attrs] == [
         {
-            'column_sql_type': model_attr.data_type,
             'tel_transformation': model_attr.data_reference,
             'taxon': prefix_with_virtual_data_source(_VIRTUAL_DATA_SOURCE, model_attr.field_map[0]),
             'identifier': model_attr.field_map[0] in identifiers,
@@ -144,11 +139,8 @@ def test_api_model_join_from_internal():
             model_name='api-model-slug-2',
             data_source='physical.table2',
             fields=[
+                FdqModelAttribute(data_reference='"col_name"', field_map=['taxon_slug_3']),
                 FdqModelAttribute(
-                    data_type=DbDataType.INTEGER, data_reference='"col_name"', field_map=['taxon_slug_3']
-                ),
-                FdqModelAttribute(
-                    data_type=DbDataType.DATE,
                     data_reference='"col_name_2"',
                     field_map=['taxon_slug', 'taxon_slug_2'],
                 ),
@@ -211,14 +203,12 @@ def test_api_model_to_internal(api_model):
                 'company_id': _COMPANY_ID,
                 'attributes': {
                     prefix_with_virtual_data_source(_VIRTUAL_DATA_SOURCE, 'taxon_slug'): {
-                        'column_sql_type': DbDataType.DATE,
                         'tel_transformation': '"col_name"',
                         'taxon': prefix_with_virtual_data_source(_VIRTUAL_DATA_SOURCE, 'taxon_slug'),
                         'identifier': True,
                     },
                     prefix_with_virtual_data_source(_VIRTUAL_DATA_SOURCE, 'taxon_slug_2'): {
                         'tel_transformation': '"another_co"',
-                        'column_sql_type': DbDataType.INTEGER,
                         'taxon': prefix_with_virtual_data_source(_VIRTUAL_DATA_SOURCE, 'taxon_slug_2'),
                         'identifier': False,
                     },

--- a/tests/panoramic/cli/husky/core/federated/model/models_test.py
+++ b/tests/panoramic/cli/husky/core/federated/model/models_test.py
@@ -1,7 +1,6 @@
 import pytest
 from pydantic import ValidationError
 
-from panoramic.cli.husky.core.enums import DbDataType
 from panoramic.cli.husky.core.federated.model.models import (
     FdqModel,
     FdqModelJoinRelationship,
@@ -27,11 +26,10 @@ def _tmp_model(fields=None, joins=None, identifiers=None):
         (
             _tmp_model(
                 [
-                    {'data_reference': '"column_name"', 'field_map': ['taxon_1'], 'data_type': DbDataType.INTEGER},
+                    {'data_reference': '"column_name"', 'field_map': ['taxon_1']},
                     {
                         'data_reference': '"column_name" + 10',
                         'field_map': ['taxon_1'],
-                        'data_type': DbDataType.INTEGER,
                     },
                 ]
             ),
@@ -41,11 +39,10 @@ def _tmp_model(fields=None, joins=None, identifiers=None):
         (
             _tmp_model(
                 [
-                    {'data_reference': '"column_name"', 'field_map': ['taxon_1'], 'data_type': DbDataType.INTEGER},
+                    {'data_reference': '"column_name"', 'field_map': ['taxon_1']},
                     {
                         'data_reference': '"column_name" + taxon_3',
                         'field_map': ['taxon_2'],
-                        'data_type': DbDataType.INTEGER,
                     },
                 ]
             ),
@@ -61,11 +58,10 @@ def _tmp_model(fields=None, joins=None, identifiers=None):
         (
             _tmp_model(
                 [
-                    {'data_reference': '"column_name"', 'field_map': ['taxon_1'], 'data_type': DbDataType.INTEGER},
+                    {'data_reference': '"column_name"', 'field_map': ['taxon_1']},
                     {
                         'data_reference': '"column_name" + taxon_2',
                         'field_map': ['taxon_2'],
-                        'data_type': DbDataType.INTEGER,
                     },
                 ]
             ),
@@ -80,16 +76,14 @@ def _tmp_model(fields=None, joins=None, identifiers=None):
         (
             _tmp_model(
                 [
-                    {'data_reference': '"column_name"', 'field_map': ['taxon_1'], 'data_type': DbDataType.INTEGER},
+                    {'data_reference': '"column_name"', 'field_map': ['taxon_1']},
                     {
                         'data_reference': '"column_name_2" + taxon_3',
                         'field_map': ['taxon_2'],
-                        'data_type': DbDataType.INTEGER,
                     },
                     {
                         'data_reference': '\"column_name_3\" + 5 / taxon_2',
                         'field_map': ['taxon_3'],
-                        'data_type': DbDataType.INTEGER,
                     },
                 ]
             ),
@@ -107,7 +101,6 @@ def _tmp_model(fields=None, joins=None, identifiers=None):
                     {
                         'data_reference': '"column_name_3" + 5 / taxon_3',
                         'field_map': ['taxon_3'],
-                        'data_type': DbDataType.INTEGER,
                     }
                 ]
             ),
@@ -122,16 +115,14 @@ def _tmp_model(fields=None, joins=None, identifiers=None):
         (
             _tmp_model(
                 [
-                    {'data_reference': '"column_name"', 'field_map': ['taxon_2'], 'data_type': DbDataType.INTEGER},
+                    {'data_reference': '"column_name"', 'field_map': ['taxon_2']},
                     {
                         'data_reference': '"column_name_2" + taxon_2',
                         'field_map': ['taxon_3'],
-                        'data_type': DbDataType.DATE,
                     },
                     {
                         'data_reference': '"column_name_3" + 5',
                         'field_map': ['taxon_4'],
-                        'data_type': DbDataType.DATE,
                     },
                 ],
                 [
@@ -152,14 +143,13 @@ def _tmp_model(fields=None, joins=None, identifiers=None):
         (
             _tmp_model(
                 [
-                    {'data_reference': '"column_name"', 'field_map': ['taxon_2'], 'data_type': DbDataType.INTEGER},
+                    {'data_reference': '"column_name"', 'field_map': ['taxon_2']},
                     {
                         'data_reference': '"column_name_2" + taxon_2',
                         'field_map': ['taxon_3', 'taxon_6'],
-                        'data_type': DbDataType.INTEGER,
                     },
-                    {'data_reference': '"column_name_3"', 'field_map': ['taxon_4'], 'data_type': DbDataType.DATE},
-                    {'data_reference': '"column_name_3"', 'field_map': ['taxon_5'], 'data_type': DbDataType.DATE},
+                    {'data_reference': '"column_name_3"', 'field_map': ['taxon_4']},
+                    {'data_reference': '"column_name_3"', 'field_map': ['taxon_5']},
                 ],
                 [
                     {
@@ -177,16 +167,14 @@ def _tmp_model(fields=None, joins=None, identifiers=None):
         (
             _tmp_model(
                 [
-                    {'data_reference': '"column_name"', 'field_map': ['taxon_1'], 'data_type': DbDataType.INTEGER},
+                    {'data_reference': '"column_name"', 'field_map': ['taxon_1']},
                     {
                         'data_reference': '"column_name_2" + taxon_3',
                         'field_map': ['taxon_x', 'taxon_5'],
-                        'data_type': DbDataType.INTEGER,
                     },
                     {
                         'data_reference': '"column_name_3" + 5 / taxon_5',
                         'field_map': ['taxon_3'],
-                        'data_type': DbDataType.INTEGER,
                     },
                 ]
             ),
@@ -200,7 +188,7 @@ def _tmp_model(fields=None, joins=None, identifiers=None):
         # identifiers not present as attributes
         (
             _tmp_model(
-                fields=[{'data_reference': '"column_name"', 'field_map': ['taxon_1'], 'data_type': DbDataType.INTEGER}],
+                fields=[{'data_reference': '"column_name"', 'field_map': ['taxon_1']}],
                 identifiers=['taxon_2'],
             ),
             [("exc=ValueError('Identifier(s) taxon_2 are not present as fields on the model') loc=('__root__',)")],

--- a/tests/panoramic/cli/husky/core/federated/model/tel/visitor_test.py
+++ b/tests/panoramic/cli/husky/core/federated/model/tel/visitor_test.py
@@ -1,6 +1,5 @@
 import pytest
 
-from panoramic.cli.husky.core.enums import DbDataType
 from panoramic.cli.husky.core.federated.model.models import FdqModelAttribute
 from panoramic.cli.husky.core.federated.model.tel.data_structures import (
     AttributeValidationTelVisitorParams,
@@ -12,11 +11,11 @@ from panoramic.cli.husky.core.tel.exceptions import TelExpressionException
 from panoramic.cli.husky.core.tel.tel_dialect import ModelTelDialect
 
 _TMP_MODEL_ATTRIBUTES = [
-    FdqModelAttribute(data_type=DbDataType.CHARACTER_VARYING, data_reference='"column_0"', field_map=['source_taxon']),
-    FdqModelAttribute(data_type=DbDataType.CHARACTER_VARYING, data_reference='"column_1"', field_map=['gender']),
-    FdqModelAttribute(data_type=DbDataType.CHARACTER_VARYING, data_reference='"column_2"', field_map=['ad_id']),
-    FdqModelAttribute(data_type=DbDataType.INTEGER, data_reference='"column_3"', field_map=['spend']),
-    FdqModelAttribute(data_type=DbDataType.INTEGER, data_reference='spend + 10', field_map=['spend_2']),
+    FdqModelAttribute(data_reference='"column_0"', field_map=['source_taxon']),
+    FdqModelAttribute(data_reference='"column_1"', field_map=['gender']),
+    FdqModelAttribute(data_reference='"column_2"', field_map=['ad_id']),
+    FdqModelAttribute(data_reference='"column_3"', field_map=['spend']),
+    FdqModelAttribute(data_reference='spend + 10', field_map=['spend_2']),
 ]
 
 

--- a/tests/panoramic/cli/test_validate.py
+++ b/tests/panoramic/cli/test_validate.py
@@ -5,7 +5,6 @@ import pytest
 import yaml
 
 from panoramic.cli.errors import (
-    DeprecatedAttributeWarning,
     FileMissingError,
     InvalidYamlFile,
     JsonSchemaError,
@@ -575,39 +574,6 @@ def test_validate_local_state_missing_field_file(tmp_path, monkeypatch):
             identifier=False,
         )
     ]
-
-
-def test_validate_local_state_deprecated_attribute(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-
-    dataset_dir = tmp_path / 'test_dataset'
-    dataset_dir.mkdir()
-
-    with (dataset_dir / PresetFileName.DATASET_YAML.value).open('w') as f:
-        f.write(yaml.dump(VALID_DATASET))
-
-    with (dataset_dir / 'test_model.model.yaml').open('w') as f:
-        f.write(
-            yaml.dump(
-                {
-                    **VALID_MODEL_MINIMAL,
-                    'fields': [
-                        {
-                            'data_type': 'CHARACTER VARYING',
-                            'field_map': ['field_slug'],
-                            'data_reference': '"FIELD_SLUG"',
-                        }
-                    ],
-                }
-            )
-        )
-
-    Paths.fields_dir(dataset_dir).mkdir()
-    with (Paths.fields_dir(dataset_dir) / 'test_field.field.yaml').open('w') as f:
-        f.write(yaml.dump(VALID_FIELD_MINIMAL))
-
-    errors = validate_local_state()
-    assert errors == [DeprecatedAttributeWarning(attribute='data_type', path=dataset_dir / 'test_model.model.yaml')]
 
 
 def test_validate_local_state_orphan_field_files(tmp_path, monkeypatch):


### PR DESCRIPTION
- Removed `column_sql_type` from internal ModelAttribute (not needed)
- Removed `data_type` from yaml model file (not needed)
- Removed ` DbDataType` enum (not needed)
- Enabled e2e test for field scaffolding (rather small change to create a separate PR)